### PR TITLE
Convert UI to mobile-first responsive design

### DIFF
--- a/src/components/BarbellSelector.tsx
+++ b/src/components/BarbellSelector.tsx
@@ -6,21 +6,28 @@ export const BarbellSelector: Component = () => {
   const store = useStore();
 
   return (
-    <div class="collapse collapse-arrow bg-base-200 rounded-sm">
-      <input type="checkbox" />
-      <div class="collapse-title text-md font-medium">
+    <fieldset class="collapse collapse-arrow bg-base-200 rounded-sm">
+      <legend class="sr-only">Barbell Weight Selection</legend>
+      <input
+        type="checkbox"
+        aria-label="Toggle barbell weight options"
+        aria-controls="barbell-options"
+      />
+      <div class="collapse-title text-sm sm:text-md font-medium">
         Barbell ({store.barWeight}lb)
       </div>
-      <div class="collapse-content flex gap-5">
+      <div id="barbell-options" class="collapse-content flex gap-3 sm:gap-5">
         <div class="form-control">
           <label class="label cursor-pointer">
             <span class="label-text">33lb</span>
             <input
               onClick={() => setBarWeight(33)}
               type="radio"
-              name="radio-10"
+              name="barbell-weight"
+              value="33"
               class="radio checked:bg-red-500"
               checked={store.barWeight === 33}
+              aria-label="Select 33lb barbell"
             />
           </label>
         </div>
@@ -30,13 +37,15 @@ export const BarbellSelector: Component = () => {
             <input
               onClick={() => setBarWeight(45)}
               type="radio"
-              name="radio-10"
+              name="barbell-weight"
+              value="45"
               class="radio checked:bg-blue-500"
               checked={store.barWeight === 45}
+              aria-label="Select 45lb barbell"
             />
           </label>
         </div>
       </div>
-    </div>
+    </fieldset>
   );
 };

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -7,16 +7,38 @@ import Navbar from "./Navbar";
 
 const Calculator: Component = () => {
   return (
-    <div class="container mx-auto w-full sm:max-w-2xl min-h-screen">
-      <div class="mx-4 pt-4 flex flex-col gap-5">
-        <Navbar />
-        <h1 class="text-3xl">Barbell Load Calculator</h1>
-        <PlateSelector />
-        <BarbellSelector />
-        <WeightControls />
-        <PlateResults />
+    <>
+      <Navbar />
+      <div class="container mx-auto max-w-full sm:max-w-2xl min-h-screen">
+        <main class="mx-3 sm:mx-4 pt-3 sm:pt-4 pb-6 flex flex-col gap-4 sm:gap-5">
+        <h1 class="text-2xl sm:text-3xl">Barbell Load Calculator</h1>
+        <section aria-labelledby="plate-selector-heading">
+          <h2 id="plate-selector-heading" class="sr-only">
+            Plate Selection
+          </h2>
+          <PlateSelector />
+        </section>
+        <section aria-labelledby="barbell-selector-heading">
+          <h2 id="barbell-selector-heading" class="sr-only">
+            Barbell Weight Selection
+          </h2>
+          <BarbellSelector />
+        </section>
+        <section aria-labelledby="weight-controls-heading">
+          <h2 id="weight-controls-heading" class="sr-only">
+            Weight Controls
+          </h2>
+          <WeightControls />
+        </section>
+        <section aria-labelledby="results-heading">
+          <h2 id="results-heading" class="sr-only">
+            Plate Distribution Results
+          </h2>
+          <PlateResults />
+        </section>
+        </main>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -6,8 +6,8 @@ const Navbar: Component = () => {
   const location = useLocation();
 
   return (
-    <div class="flex items-center justify-between gap-4">
-      <ul class="menu menu-horizontal lg:menu-horizontal bg-base-200 rounded-sm">
+    <div class="flex items-center justify-between gap-2 sm:gap-4 w-full bg-base-200">
+      <ul class="menu menu-horizontal text-sm sm:text-base flex-1">
         <li classList={{ active: location.pathname === "/" }}>
           <A href="/">
             Home
@@ -19,7 +19,9 @@ const Navbar: Component = () => {
           </A>
         </li>
       </ul>
-      <ThemeToggle />
+      <div class="pr-3 sm:pr-4">
+        <ThemeToggle />
+      </div>
     </div>
   );
 };

--- a/src/components/PlateResults.tsx
+++ b/src/components/PlateResults.tsx
@@ -17,12 +17,12 @@ export const PlateResults: Component = () => {
   });
 
   return (
-    <div class="p-4 bg-base-200 rounded-sm">
-      <h2 class="pb-3 text-xl font-semibold">
-        For {store.percentageWeight}lb you'll need:
+    <div class="p-3 sm:p-4 bg-base-200 rounded-sm">
+      <h2 class="pb-2 sm:pb-3 text-lg sm:text-xl font-semibold">
+        For {store.percentageWeight.toFixed(2)}lb you'll need:
       </h2>
       <Show when={plates()}>
-        <ul class="list-disc px-4 text-md text-lg">
+        <ul class="list-disc px-3 sm:px-4 text-base sm:text-lg">
           {plates()?.map(({ count, weight }) => (
             <li>
               {count} plate(s) of {weight}lb per side
@@ -31,7 +31,7 @@ export const PlateResults: Component = () => {
         </ul>
       </Show>
       <Show when={plates()?.length === 0}>
-        <p class="text-lg">Just the barbell 😀</p>
+        <p class="text-base sm:text-lg">Just the barbell 😀</p>
       </Show>
       <Show when={isLessThanTheBarbell()}>
         <small>(that's not even the barbell weight but that's okay!)</small>

--- a/src/components/PlateSelector.tsx
+++ b/src/components/PlateSelector.tsx
@@ -19,12 +19,12 @@ export const PlateSelector: Component = () => {
   return (
     <div class="collapse collapse-arrow bg-base-200 rounded-sm">
       <input type="checkbox" />
-      <div class="collapse-title text-md font-medium">Plates available</div>
+      <div class="collapse-title text-sm sm:text-md font-medium">Plates available</div>
       <div class="collapse-content">
-        <div class="grid gap-2 sm:grid-cols-4 grid-cols-4">
+        <div class="grid gap-2 grid-cols-2 sm:grid-cols-3 md:grid-cols-4">
           {store.selectedPlates.map(({ enabled, weight }, index) => (
             <button
-              class="btn bg-base-300 hover:bg-base-100 btn-block px-5 btn-lg h-24 flex flex-col justify-center items-center no-animation text-base-content font-normal"
+              class="btn bg-base-300 hover:bg-base-100 btn-block px-3 sm:px-5 btn-md sm:btn-lg h-20 sm:h-24 flex flex-col justify-center items-center no-animation text-base-content font-normal"
               onClick={() => handlePlateCheckbox(index)}
             >
               <label for={`${weight}-plate`}>{`${weight} lb`}</label>

--- a/src/components/WeightControls.tsx
+++ b/src/components/WeightControls.tsx
@@ -48,13 +48,13 @@ export const WeightControls: Component = () => {
   });
 
   return (
-    <div class="flex gap-4 w-full">
-      <label class="form-control w-2/5">
+    <div class="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full">
+      <label class="form-control w-full sm:w-2/5">
         <div class="label">
-          <span class="label-text text-lg font-semibold">Target weight</span>
+          <span class="label-text text-base sm:text-lg font-semibold">Target weight</span>
         </div>
         <input
-          class="input input-bordered input-lg rounded-sm w-full text-2xl px-4 text-center"
+          class="input input-bordered input-md sm:input-lg rounded-sm w-full text-xl sm:text-2xl px-4 text-center"
           value={store.weight}
           type="number"
           inputmode="numeric"
@@ -62,24 +62,27 @@ export const WeightControls: Component = () => {
           min={store.barWeight}
           max={MAX_WEIGHT}
           onChange={handleWeightInputChange}
+          aria-label="Target weight in pounds"
         />
       </label>
-      <div class="form-control w-3/5">
-        <div class="label">
-          <span class="label-text text-lg font-semibold">Target %</span>
-        </div>
-        <div class="join w-full h-12 text-xl">
+      <fieldset class="form-control w-full sm:w-3/5">
+        <legend class="label">
+          <span class="label-text text-base sm:text-lg font-semibold">Target %</span>
+        </legend>
+        <div class="join w-full h-10 sm:h-12 text-base sm:text-xl">
           <button
-            class="btn join-item btn-lg text-xl rounded-sm"
+            class="btn join-item btn-md sm:btn-lg text-base sm:text-xl rounded-sm"
             disabled={decrementButtonDisabled()}
             onClick={() => {
               updatePercentageWeight(store.percentage - PERCENTAGE_STEP);
             }}
+            aria-label="Decrease percentage by 5%"
+            title="Decrease percentage"
           >
             -
           </button>
           <input
-            class="input input-lg rounded-sm  flex-1 min-w-0 text-2xl px-4 text-center cursor-default disabled:opacity-100 disabled:bg-white"
+            class="input input-md sm:input-lg rounded-sm  flex-1 min-w-0 text-xl sm:text-2xl px-4 text-center cursor-default disabled:opacity-100 disabled:bg-white"
             value={store.percentage}
             type="number"
             inputmode="numeric"
@@ -87,18 +90,21 @@ export const WeightControls: Component = () => {
             min={MIN_PERCENTAGE}
             max={MAX_PERCENTAGE}
             onChange={handlePercentageInputChange}
+            aria-label="Target percentage"
           />
           <button
             disabled={increaseButtonDisabled()}
-            class="btn join-item btn-lg text-xl rounded-sm"
+            class="btn join-item btn-md sm:btn-lg text-base sm:text-xl rounded-sm"
             onClick={() => {
               updatePercentageWeight(store.percentage + PERCENTAGE_STEP);
             }}
+            aria-label="Increase percentage by 5%"
+            title="Increase percentage"
           >
             +
           </button>
         </div>
-      </div>
+      </fieldset>
     </div>
   );
 };

--- a/src/components/plates/Plates.tsx
+++ b/src/components/plates/Plates.tsx
@@ -32,41 +32,42 @@ const Plates: Component = () => {
   };
 
   return (
-    <div class="container mx-auto w-full sm:max-w-2xl min-h-screen">
-      <div class="mx-4 pt-4 flex flex-col gap-5">
-        <Navbar />
-        <h1 class="text-3xl">
+    <>
+      <Navbar />
+      <div class="container mx-auto max-w-full sm:max-w-2xl min-h-screen">
+        <div class="mx-3 sm:mx-4 pt-3 sm:pt-4 pb-6 flex flex-col gap-4 sm:gap-5">
+        <h1 class="text-2xl sm:text-3xl">
           Calculate by plate <small class="text-sm">(experimental)</small>
         </h1>
         <BarbellSelector />
         <div class="sticky top-2 z-10">
-          <div class="p-4 rounded-lg bg-base-200 border-2">
-            <p class="text-xl font-bold">Total Weight: {totalWeight()}lbs</p>
-            <p class="text-sm">
+          <div class="p-3 sm:p-4 rounded-lg bg-base-200 border-2">
+            <p class="text-lg sm:text-xl font-bold">Total Weight: {totalWeight()}lbs</p>
+            <p class="text-xs sm:text-sm">
               (Including {store.barWeight}lb barbell)
             </p>
           </div>
         </div>
-        <div class="grid grid-cols-2 lg:grid-cols-3 gap-4">
+        <div class="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
           <For each={availablePlates}>
             {(plate) => (
-              <div class="flex flex-col items-center justify-between px-2 py-4 bg-base-300 rounded gap-5">
-                <span class="text-lg font-medium">{plate.weight}lb plate</span>
-                <div class="flex items-center gap-1">
+              <div class="flex flex-col items-center justify-between px-2 sm:px-3 py-3 sm:py-4 bg-base-300 rounded gap-3 sm:gap-4">
+                <span class="text-base sm:text-lg font-medium">{plate.weight}lb plate</span>
+                <div class="flex items-center gap-2 sm:gap-3">
                   <button
                     onClick={() => handleDecrement(plate.weight)}
-                    class="px-3 py-1 bg-warning text-white rounded-md hover:bg-red-600 disabled:opacity-50"
+                    class="px-2 sm:px-3 py-1 text-sm sm:text-base bg-warning text-white rounded-md hover:bg-red-600 disabled:opacity-50"
                     disabled={plateCounts()[plate.weight] === 0}
                     aria-label={`Decrease ${plate.weight}lb plates`}
                   >
                     -
                   </button>
-                  <span class="w-8 text-center">
+                  <span class="w-6 sm:w-8 text-center text-sm sm:text-base">
                     {plateCounts()[plate.weight]}
                   </span>
                   <button
                     onClick={() => handleIncrement(plate.weight)}
-                    class="px-3 py-1 bg-success text-white rounded-md hover:bg-green-600"
+                    class="px-2 sm:px-3 py-1 text-sm sm:text-base bg-success text-white rounded-md hover:bg-green-600"
                     aria-label={`Increase ${plate.weight}lb plates`}
                   >
                     +
@@ -76,8 +77,9 @@ const Plates: Component = () => {
             )}
           </For>
         </div>
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
- Stack components vertically on mobile, horizontal on sm+
- Responsive text sizes and spacing with Tailwind breakpoints
- DaisyUI size modifiers (btn-md/input-md on mobile, sm:btn-lg/input-lg)
- Full-width navbar with proper padding
- 2-col to 4-col grid progression for plate selector
- Unified padding across both routes