### PR TITLE
feat: add training session logger

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,57 @@
+# Testing Instructions — Training Logger & Progress Charts
+
+## Automated tests
+
+```bash
+pnpm test
+```
+
+Expect 40 tests passing (15 calculator + 13 training + 12 progress).
+
+## Manual testing — Training tab
+
+1. **Navigate to the Training tab** (clipboard icon in bottom nav)
+2. **Empty state**: should show a "New Session" button and no past sessions
+3. **Create a session**: tap "New Session"
+   - Should see today's date at the top and a back arrow
+   - Should see an "Add Exercise" button
+4. **Add a weight exercise**:
+   - Tap "Add Exercise" — exercise picker appears with search and filter (All/Weight/Cardio)
+   - Search for "bench" — should filter to "Bench Press"
+   - Select "Bench Press" — picker closes, exercise card appears
+   - Enter reps: `10`, weight: `135`, tap the purple + button — set 1 appears (10 reps, 135 lb)
+   - Add 2 more sets with different reps/weights
+   - Verify set numbers display correctly (1, 2, 3)
+   - Tap the X on a set — set is removed
+5. **Add a cardio exercise**:
+   - Tap "Add Exercise" — tap "Cardio" filter
+   - Select "200m Run" — card shows Time + Duration inputs (not reps/weight)
+   - Enter value `28`, duration `28`, tap + — set appears showing time and duration
+   - Select "Laps" — card shows only "Laps" input (no duration field)
+   - Enter `5`, tap + — set appears
+6. **Remove an exercise**: tap "Remove" on an exercise card — entire entry removed
+7. **Back to list**: tap the back arrow
+   - Session should appear in "Past Sessions" with date and exercise tags (e.g. "Bench Press (3)")
+8. **Edit a session**: tap "Edit" on a past session — returns to editor with all data intact
+9. **Delete a session**: tap "Delete" — session removed from list
+10. **Persistence**: refresh the page — past sessions should still be there (localStorage)
+
+## Manual testing — Progress tab
+
+1. **Empty state**: navigate to Progress tab (bar chart icon) with no sessions — should show "Log some training sessions to see your progress"
+2. **With data**: after logging at least 2 sessions with the same weight exercise:
+   - Exercise pills should appear (only exercises that have logged sets)
+   - Selecting a weight exercise shows 2 charts: "Max Weight" (purple) and "Total Volume" (teal)
+   - Charts should have Y-axis values, X-axis dates, data points, and gradient fill
+   - Latest value shown in top-right of each chart
+3. **Cardio progress**: log 2+ sessions with a cardio exercise
+   - Selecting a cardio exercise shows 1 chart: "Best Time" or "Total Laps"
+4. **Single data point**: with only 1 session for an exercise, chart shows "Need at least 2 sessions to plot"
+5. **Switching exercises**: tap different exercise pills — charts update immediately
+
+## Edge cases
+
+- [ ] Adding a set with 0 or empty reps/weight should not create a set
+- [ ] Creating a session and immediately going back shows it in the list (even with no exercises)
+- [ ] Both light and dark themes render charts correctly
+- [ ] Tab bar shows 5 tabs without layout issues on mobile viewport

--- a/packages/shared/src/__tests__/progress.test.ts
+++ b/packages/shared/src/__tests__/progress.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import {
+  getExerciseMaxWeight,
+  getExerciseTotalVolume,
+  getCardioBestValue,
+  getExercisesWithData,
+  type DataPoint,
+} from "../progress";
+import type { TrainingSession, WeightSet, CardioSet } from "../training";
+
+const makeSessions = (): TrainingSession[] => [
+  {
+    id: "1",
+    date: "2026-02-10",
+    entries: [
+      {
+        exerciseId: "bench-press",
+        sets: [
+          { reps: 10, weight: 135 },
+          { reps: 8, weight: 155 },
+          { reps: 5, weight: 185 },
+        ] as WeightSet[],
+      },
+      {
+        exerciseId: "200m-run",
+        sets: [{ value: 32 }, { value: 29, duration: 29 }] as CardioSet[],
+      },
+    ],
+  },
+  {
+    id: "2",
+    date: "2026-02-12",
+    entries: [
+      {
+        exerciseId: "bench-press",
+        sets: [
+          { reps: 10, weight: 145 },
+          { reps: 8, weight: 165 },
+          { reps: 3, weight: 195 },
+        ] as WeightSet[],
+      },
+    ],
+  },
+  {
+    id: "3",
+    date: "2026-02-14",
+    entries: [
+      {
+        exerciseId: "laps",
+        sets: [{ value: 4 }, { value: 6 }] as CardioSet[],
+      },
+    ],
+  },
+  {
+    id: "4",
+    date: "2026-02-15",
+    entries: [{ exerciseId: "squat", sets: [] }],
+  },
+];
+
+describe("getExerciseMaxWeight", () => {
+  it("returns max weight per session sorted by date", () => {
+    const result = getExerciseMaxWeight(makeSessions(), "bench-press");
+    expect(result).toEqual([
+      { date: "2026-02-10", value: 185 },
+      { date: "2026-02-12", value: 195 },
+    ]);
+  });
+
+  it("returns empty for exercise not in sessions", () => {
+    expect(getExerciseMaxWeight(makeSessions(), "deadlift")).toEqual([]);
+  });
+
+  it("returns empty for empty sessions", () => {
+    expect(getExerciseMaxWeight([], "bench-press")).toEqual([]);
+  });
+
+  it("skips entries with no sets", () => {
+    expect(getExerciseMaxWeight(makeSessions(), "squat")).toEqual([]);
+  });
+});
+
+describe("getExerciseTotalVolume", () => {
+  it("returns total volume (reps * weight) per session", () => {
+    const result = getExerciseTotalVolume(makeSessions(), "bench-press");
+    expect(result).toEqual([
+      { date: "2026-02-10", value: 10 * 135 + 8 * 155 + 5 * 185 },
+      { date: "2026-02-12", value: 10 * 145 + 8 * 165 + 3 * 195 },
+    ]);
+  });
+
+  it("returns empty for missing exercise", () => {
+    expect(getExerciseTotalVolume(makeSessions(), "deadlift")).toEqual([]);
+  });
+});
+
+describe("getCardioBestValue", () => {
+  it("returns best (lowest) time for time-based cardio", () => {
+    const result = getCardioBestValue(makeSessions(), "200m-run");
+    expect(result).toEqual([{ date: "2026-02-10", value: 29 }]);
+  });
+
+  it("returns total laps for lap-based cardio", () => {
+    const result = getCardioBestValue(makeSessions(), "laps");
+    expect(result).toEqual([{ date: "2026-02-14", value: 10 }]);
+  });
+
+  it("returns empty for weight exercise", () => {
+    expect(getCardioBestValue(makeSessions(), "bench-press")).toEqual([]);
+  });
+
+  it("returns empty for unknown exercise", () => {
+    expect(getCardioBestValue(makeSessions(), "nonexistent")).toEqual([]);
+  });
+});
+
+describe("getExercisesWithData", () => {
+  it("returns exercise ids that have at least one set", () => {
+    const result = getExercisesWithData(makeSessions());
+    expect(result).toContain("bench-press");
+    expect(result).toContain("200m-run");
+    expect(result).toContain("laps");
+    expect(result).not.toContain("squat");
+  });
+
+  it("returns empty for no sessions", () => {
+    expect(getExercisesWithData([])).toEqual([]);
+  });
+});

--- a/packages/shared/src/__tests__/training.test.ts
+++ b/packages/shared/src/__tests__/training.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  exercises,
+  getExerciseById,
+  generateSessionId,
+  type Exercise,
+  type TrainingSession,
+  type WeightSet,
+  type CardioSet,
+} from "../training";
+
+describe("exercises", () => {
+  it("contains both weight and cardio exercises", () => {
+    const weightExercises = exercises.filter((e) => e.type === "weight");
+    const cardioExercises = exercises.filter((e) => e.type === "cardio");
+    expect(weightExercises.length).toBeGreaterThan(0);
+    expect(cardioExercises.length).toBeGreaterThan(0);
+  });
+
+  it("has unique ids", () => {
+    const ids = exercises.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("cardio exercises have a unit", () => {
+    const cardio = exercises.filter((e) => e.type === "cardio");
+    cardio.forEach((e) => {
+      expect(e.unit).toBeDefined();
+    });
+  });
+
+  it("weight exercises do not have a unit", () => {
+    const weight = exercises.filter((e) => e.type === "weight");
+    weight.forEach((e) => {
+      expect(e.unit).toBeUndefined();
+    });
+  });
+});
+
+describe("getExerciseById", () => {
+  it("returns exercise for valid id", () => {
+    const result = getExerciseById("bench-press");
+    expect(result).toBeDefined();
+    expect(result!.name).toBe("Bench Press");
+    expect(result!.type).toBe("weight");
+  });
+
+  it("returns undefined for invalid id", () => {
+    expect(getExerciseById("nonexistent")).toBeUndefined();
+  });
+
+  it("returns cardio exercise with unit", () => {
+    const result = getExerciseById("200m-run");
+    expect(result).toBeDefined();
+    expect(result!.type).toBe("cardio");
+    expect(result!.unit).toBe("seconds");
+  });
+});
+
+describe("generateSessionId", () => {
+  it("returns a non-empty string", () => {
+    const id = generateSessionId();
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it("generates unique ids", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateSessionId()));
+    expect(ids.size).toBe(100);
+  });
+});
+
+describe("types", () => {
+  it("WeightSet shape is valid", () => {
+    const set: WeightSet = { reps: 10, weight: 135 };
+    expect(set.reps).toBe(10);
+    expect(set.weight).toBe(135);
+  });
+
+  it("CardioSet shape is valid", () => {
+    const set: CardioSet = { value: 200, duration: 30 };
+    expect(set.value).toBe(200);
+    expect(set.duration).toBe(30);
+  });
+
+  it("CardioSet duration is optional", () => {
+    const set: CardioSet = { value: 5 };
+    expect(set.value).toBe(5);
+    expect(set.duration).toBeUndefined();
+  });
+
+  it("TrainingSession shape is valid", () => {
+    const session: TrainingSession = {
+      id: "test-123",
+      date: "2026-02-17",
+      entries: [
+        {
+          exerciseId: "bench-press",
+          sets: [{ reps: 10, weight: 135 }] as WeightSet[],
+        },
+        {
+          exerciseId: "200m-run",
+          sets: [{ value: 200, duration: 28 }] as CardioSet[],
+        },
+      ],
+    };
+    expect(session.entries.length).toBe(2);
+  });
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -3,6 +3,7 @@ export const STORAGE_KEY = "selectedPlates";
 export const WEIGHT_STORAGE_KEY = "barbell-weight";
 export const PERCENTAGE_STORAGE_KEY = "barbell-percentage";
 export const BAR_WEIGHT_STORAGE_KEY = "barbell-bar-weight";
+export const TRAINING_SESSIONS_STORAGE_KEY = "training-sessions";
 
 // Input constraints
 export const MIN_PERCENTAGE = 40;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from './calculators';
 export * from './constants';
+export * from './training';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from './calculators';
 export * from './constants';
 export * from './training';
+export * from './progress';

--- a/packages/shared/src/progress.ts
+++ b/packages/shared/src/progress.ts
@@ -1,0 +1,80 @@
+import type { TrainingSession, WeightSet, CardioSet } from "./training";
+import { getExerciseById } from "./training";
+
+export type ProgressMetric = "max_weight" | "total_volume" | "best_value";
+
+export type DataPoint = {
+  date: string;
+  value: number;
+};
+
+export const getExerciseMaxWeight = (
+  sessions: TrainingSession[],
+  exerciseId: string
+): DataPoint[] => {
+  const points: DataPoint[] = [];
+  for (const session of sessions) {
+    for (const entry of session.entries) {
+      if (entry.exerciseId !== exerciseId) continue;
+      const sets = entry.sets as WeightSet[];
+      if (sets.length === 0) continue;
+      const max = Math.max(...sets.map((s) => s.weight));
+      points.push({ date: session.date, value: max });
+    }
+  }
+  return points.sort((a, b) => a.date.localeCompare(b.date));
+};
+
+export const getExerciseTotalVolume = (
+  sessions: TrainingSession[],
+  exerciseId: string
+): DataPoint[] => {
+  const points: DataPoint[] = [];
+  for (const session of sessions) {
+    for (const entry of session.entries) {
+      if (entry.exerciseId !== exerciseId) continue;
+      const sets = entry.sets as WeightSet[];
+      if (sets.length === 0) continue;
+      const volume = sets.reduce((sum, s) => sum + s.reps * s.weight, 0);
+      points.push({ date: session.date, value: volume });
+    }
+  }
+  return points.sort((a, b) => a.date.localeCompare(b.date));
+};
+
+export const getCardioBestValue = (
+  sessions: TrainingSession[],
+  exerciseId: string
+): DataPoint[] => {
+  const exercise = getExerciseById(exerciseId);
+  if (!exercise || exercise.type !== "cardio") return [];
+
+  const points: DataPoint[] = [];
+  for (const session of sessions) {
+    for (const entry of session.entries) {
+      if (entry.exerciseId !== exerciseId) continue;
+      const sets = entry.sets as CardioSet[];
+      if (sets.length === 0) continue;
+      if (exercise.unit === "laps") {
+        const total = sets.reduce((sum, s) => sum + s.value, 0);
+        points.push({ date: session.date, value: total });
+      } else {
+        const best = Math.min(...sets.map((s) => s.value));
+        points.push({ date: session.date, value: best });
+      }
+    }
+  }
+  return points.sort((a, b) => a.date.localeCompare(b.date));
+};
+
+export const getExercisesWithData = (
+  sessions: TrainingSession[]
+): string[] => {
+  const ids = new Set<string>();
+  for (const session of sessions) {
+    for (const entry of session.entries) {
+      if (entry.sets.length > 0) ids.add(entry.exerciseId);
+    }
+  }
+  return [...ids];
+};

--- a/packages/shared/src/training.ts
+++ b/packages/shared/src/training.ts
@@ -1,0 +1,60 @@
+export type ExerciseType = "weight" | "cardio";
+
+export type Exercise = {
+  id: string;
+  name: string;
+  type: ExerciseType;
+  unit?: string;
+};
+
+export type WeightSet = {
+  reps: number;
+  weight: number;
+};
+
+export type CardioSet = {
+  value: number;
+  duration?: number;
+};
+
+export type ExerciseEntry = {
+  exerciseId: string;
+  sets: WeightSet[] | CardioSet[];
+};
+
+export type TrainingSession = {
+  id: string;
+  date: string;
+  entries: ExerciseEntry[];
+};
+
+export const exercises: Exercise[] = [
+  { id: "bench-press", name: "Bench Press", type: "weight" },
+  { id: "squat", name: "Squat", type: "weight" },
+  { id: "front-squat", name: "Front Squat", type: "weight" },
+  { id: "deadlift", name: "Deadlift", type: "weight" },
+  { id: "overhead-press", name: "Overhead Press", type: "weight" },
+  { id: "barbell-row", name: "Barbell Row", type: "weight" },
+  { id: "dumbbell-curl", name: "Dumbbell Curl", type: "weight" },
+  { id: "tricep-extension", name: "Tricep Extension", type: "weight" },
+  { id: "lat-pulldown", name: "Lat Pulldown", type: "weight" },
+  { id: "leg-press", name: "Leg Press", type: "weight" },
+  { id: "romanian-deadlift", name: "Romanian Deadlift", type: "weight" },
+  { id: "hip-thrust", name: "Hip Thrust", type: "weight" },
+  { id: "lateral-raise", name: "Lateral Raise", type: "weight" },
+  { id: "face-pull", name: "Face Pull", type: "weight" },
+  { id: "cable-fly", name: "Cable Fly", type: "weight" },
+  { id: "200m-run", name: "200m Run", type: "cardio", unit: "seconds" },
+  { id: "400m-run", name: "400m Run", type: "cardio", unit: "seconds" },
+  { id: "800m-run", name: "800m Run", type: "cardio", unit: "seconds" },
+  { id: "1600m-run", name: "1600m Run", type: "cardio", unit: "seconds" },
+  { id: "laps", name: "Laps", type: "cardio", unit: "laps" },
+  { id: "jump-rope", name: "Jump Rope", type: "cardio", unit: "seconds" },
+  { id: "rowing-machine", name: "Rowing Machine", type: "cardio", unit: "seconds" },
+];
+
+export const getExerciseById = (id: string): Exercise | undefined =>
+  exercises.find((e) => e.id === id);
+
+export const generateSessionId = (): string =>
+  Date.now().toString(36) + Math.random().toString(36).slice(2, 7);

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -3,11 +3,13 @@ import Calculator from "./components/Calculator";
 import { Router, Route } from "@solidjs/router";
 import Plates from "./components/plates/Plates";
 import Settings from "./components/Settings";
+import Training from "./components/training/Training";
 
 const App: Component = () => (
   <Router>
     <Route path="/" component={Calculator} />
     <Route path="/plates" component={Plates} />
+    <Route path="/training" component={Training} />
     <Route path="/settings" component={Settings} />
   </Router>
 );

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -4,12 +4,14 @@ import { Router, Route } from "@solidjs/router";
 import Plates from "./components/plates/Plates";
 import Settings from "./components/Settings";
 import Training from "./components/training/Training";
+import Progress from "./components/progress/Progress";
 
 const App: Component = () => (
   <Router>
     <Route path="/" component={Calculator} />
     <Route path="/plates" component={Plates} />
     <Route path="/training" component={Training} />
+    <Route path="/progress" component={Progress} />
     <Route path="/settings" component={Settings} />
   </Router>
 );

--- a/packages/web/src/components/TabBar.tsx
+++ b/packages/web/src/components/TabBar.tsx
@@ -80,6 +80,39 @@ export const TabBar: Component = () => {
       </A>
 
       <A
+        href="/training"
+        class="flex flex-col items-center justify-center gap-1 py-2 px-3 flex-1"
+        aria-current={isActive("/training") ? "page" : undefined}
+      >
+        <svg
+          class="w-6 h-6"
+          classList={{
+            "text-purple": isActive("/training"),
+            "text-tertiary-color": !isActive("/training"),
+          }}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
+          />
+        </svg>
+        <span
+          class="text-[13px] font-inter"
+          classList={{
+            "font-semibold text-purple": isActive("/training"),
+            "font-medium text-tertiary-color": !isActive("/training"),
+          }}
+        >
+          Training
+        </span>
+      </A>
+
+      <A
         href="/settings"
         class="flex flex-col items-center justify-center gap-1 py-2 px-3 flex-1"
         aria-current={isActive("/settings") ? "page" : undefined}

--- a/packages/web/src/components/TabBar.tsx
+++ b/packages/web/src/components/TabBar.tsx
@@ -113,6 +113,39 @@ export const TabBar: Component = () => {
       </A>
 
       <A
+        href="/progress"
+        class="flex flex-col items-center justify-center gap-1 py-2 px-3 flex-1"
+        aria-current={isActive("/progress") ? "page" : undefined}
+      >
+        <svg
+          class="w-5 h-5"
+          classList={{
+            "text-purple": isActive("/progress"),
+            "text-tertiary-color": !isActive("/progress"),
+          }}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"
+          />
+        </svg>
+        <span
+          class="text-[13px] font-inter"
+          classList={{
+            "font-semibold text-purple": isActive("/progress"),
+            "font-medium text-tertiary-color": !isActive("/progress"),
+          }}
+        >
+          Progress
+        </span>
+      </A>
+
+      <A
         href="/settings"
         class="flex flex-col items-center justify-center gap-1 py-2 px-3 flex-1"
         aria-current={isActive("/settings") ? "page" : undefined}

--- a/packages/web/src/components/progress/LineChart.tsx
+++ b/packages/web/src/components/progress/LineChart.tsx
@@ -1,0 +1,168 @@
+import { type Component, createMemo, For, Show } from "solid-js";
+import type { DataPoint } from "@barbell/shared";
+
+interface LineChartProps {
+  data: DataPoint[];
+  label: string;
+  unit: string;
+  color?: string;
+}
+
+const CHART_W = 320;
+const CHART_H = 180;
+const PAD_L = 48;
+const PAD_R = 12;
+const PAD_T = 16;
+const PAD_B = 40;
+
+const formatShortDate = (d: string) => {
+  const [, m, day] = d.split("-");
+  return `${parseInt(m)}/${parseInt(day)}`;
+};
+
+const LineChart: Component<LineChartProps> = (props) => {
+  const color = () => props.color ?? "var(--accent-purple)";
+
+  const bounds = createMemo(() => {
+    const vals = props.data.map((d) => d.value);
+    const min = Math.min(...vals);
+    const max = Math.max(...vals);
+    const range = max - min || 1;
+    const padding = range * 0.1;
+    return { min: min - padding, max: max + padding };
+  });
+
+  const plotW = () => CHART_W - PAD_L - PAD_R;
+  const plotH = () => CHART_H - PAD_T - PAD_B;
+
+  const toX = (i: number) =>
+    PAD_L + (props.data.length === 1 ? plotW() / 2 : (i / (props.data.length - 1)) * plotW());
+
+  const toY = (v: number) => {
+    const { min, max } = bounds();
+    return PAD_T + plotH() - ((v - min) / (max - min)) * plotH();
+  };
+
+  const linePath = createMemo(() => {
+    if (props.data.length === 0) return "";
+    return props.data
+      .map((d, i) => `${i === 0 ? "M" : "L"}${toX(i).toFixed(1)},${toY(d.value).toFixed(1)}`)
+      .join(" ");
+  });
+
+  const areaPath = createMemo(() => {
+    if (props.data.length === 0) return "";
+    const base = PAD_T + plotH();
+    const line = props.data
+      .map((d, i) => `${i === 0 ? "M" : "L"}${toX(i).toFixed(1)},${toY(d.value).toFixed(1)}`)
+      .join(" ");
+    return `${line} L${toX(props.data.length - 1).toFixed(1)},${base} L${toX(0).toFixed(1)},${base} Z`;
+  });
+
+  const yTicks = createMemo(() => {
+    const { min, max } = bounds();
+    const count = 4;
+    return Array.from({ length: count + 1 }, (_, i) => {
+      const v = min + ((max - min) / count) * i;
+      return { value: v, y: toY(v) };
+    });
+  });
+
+  const xLabels = createMemo(() => {
+    const len = props.data.length;
+    if (len <= 5) return props.data.map((d, i) => ({ label: formatShortDate(d.date), x: toX(i) }));
+    const step = Math.ceil(len / 5);
+    const labels: { label: string; x: number }[] = [];
+    for (let i = 0; i < len; i += step) {
+      labels.push({ label: formatShortDate(props.data[i].date), x: toX(i) });
+    }
+    if ((len - 1) % step !== 0) {
+      labels.push({ label: formatShortDate(props.data[len - 1].date), x: toX(len - 1) });
+    }
+    return labels;
+  });
+
+  return (
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center justify-between">
+        <span class="text-sm font-inter font-semibold text-primary-color">{props.label}</span>
+        <Show when={props.data.length > 0}>
+          <span class="text-sm font-inter font-bold" style={{ color: color() }}>
+            {props.data[props.data.length - 1].value.toFixed(0)} {props.unit}
+          </span>
+        </Show>
+      </div>
+      <Show
+        when={props.data.length >= 2}
+        fallback={
+          <div class="flex items-center justify-center h-[180px] rounded-xl bg-elevated">
+            <span class="text-sm font-inter text-tertiary-color">
+              {props.data.length === 1 ? "Need at least 2 sessions to plot" : "No data yet"}
+            </span>
+          </div>
+        }
+      >
+        <svg viewBox={`0 0 ${CHART_W} ${CHART_H}`} class="w-full rounded-xl bg-elevated" preserveAspectRatio="xMidYMid meet">
+          <For each={yTicks()}>
+            {(tick) => (
+              <>
+                <line
+                  x1={PAD_L}
+                  y1={tick.y}
+                  x2={CHART_W - PAD_R}
+                  y2={tick.y}
+                  stroke="var(--text-muted)"
+                  stroke-width="0.5"
+                  stroke-dasharray="3,3"
+                />
+                <text
+                  x={PAD_L - 6}
+                  y={tick.y + 3}
+                  text-anchor="end"
+                  fill="var(--text-tertiary)"
+                  font-size="9"
+                  font-family="Inter, sans-serif"
+                >
+                  {tick.value.toFixed(0)}
+                </text>
+              </>
+            )}
+          </For>
+
+          <defs>
+            <linearGradient id={`grad-${props.label}`} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color={color()} stop-opacity="0.25" />
+              <stop offset="100%" stop-color={color()} stop-opacity="0.02" />
+            </linearGradient>
+          </defs>
+
+          <path d={areaPath()} fill={`url(#grad-${props.label})`} />
+          <path d={linePath()} fill="none" stroke={color()} stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+
+          <For each={props.data}>
+            {(d, i) => (
+              <circle cx={toX(i())} cy={toY(d.value)} r="3" fill={color()} />
+            )}
+          </For>
+
+          <For each={xLabels()}>
+            {(label) => (
+              <text
+                x={label.x}
+                y={CHART_H - 8}
+                text-anchor="middle"
+                fill="var(--text-tertiary)"
+                font-size="9"
+                font-family="Inter, sans-serif"
+              >
+                {label.label}
+              </text>
+            )}
+          </For>
+        </svg>
+      </Show>
+    </div>
+  );
+};
+
+export default LineChart;

--- a/packages/web/src/components/progress/Progress.tsx
+++ b/packages/web/src/components/progress/Progress.tsx
@@ -1,0 +1,154 @@
+import { type Component, createSignal, createMemo, For, Show } from "solid-js";
+import Layout from "../Layout";
+import LineChart from "./LineChart";
+import { useTrainingStore } from "../../stores/trainingStore";
+import {
+  getExerciseById,
+  getExercisesWithData,
+  getExerciseMaxWeight,
+  getExerciseTotalVolume,
+  getCardioBestValue,
+} from "@barbell/shared";
+
+const Progress: Component = () => {
+  const store = useTrainingStore();
+  const [selectedExercise, setSelectedExercise] = createSignal<string | null>(null);
+
+  const exercisesWithData = createMemo(() =>
+    getExercisesWithData(store.sessions)
+  );
+
+  const selected = createMemo(() => {
+    const id = selectedExercise();
+    if (id && exercisesWithData().includes(id)) return id;
+    return exercisesWithData()[0] ?? null;
+  });
+
+  const exercise = createMemo(() => {
+    const id = selected();
+    return id ? getExerciseById(id) : undefined;
+  });
+
+  const isWeight = () => exercise()?.type === "weight";
+
+  const maxWeightData = createMemo(() => {
+    const id = selected();
+    if (!id || !isWeight()) return [];
+    return getExerciseMaxWeight(store.sessions, id);
+  });
+
+  const volumeData = createMemo(() => {
+    const id = selected();
+    if (!id || !isWeight()) return [];
+    return getExerciseTotalVolume(store.sessions, id);
+  });
+
+  const cardioData = createMemo(() => {
+    const id = selected();
+    if (!id || isWeight()) return [];
+    return getCardioBestValue(store.sessions, id);
+  });
+
+  const cardioLabel = createMemo(() => {
+    const e = exercise();
+    if (!e) return "";
+    if (e.unit === "laps") return "Total Laps";
+    return "Best Time";
+  });
+
+  const cardioUnit = createMemo(() => {
+    const e = exercise();
+    if (!e) return "";
+    if (e.unit === "laps") return "laps";
+    return "s";
+  });
+
+  return (
+    <Layout>
+      <header class="flex items-center justify-between py-4">
+        <h1 class="text-4xl font-bold font-jakarta text-primary-color">
+          Progress
+        </h1>
+      </header>
+
+      <Show
+        when={exercisesWithData().length > 0}
+        fallback={
+          <div class="flex flex-col items-center justify-center gap-3 py-16">
+            <svg
+              class="w-12 h-12 text-tertiary-color"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="1.5"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"
+              />
+            </svg>
+            <span class="text-sm font-inter text-tertiary-color text-center">
+              Log some training sessions to see your progress
+            </span>
+          </div>
+        }
+      >
+        <div class="flex flex-col gap-5">
+          <div class="flex flex-col gap-2">
+            <h2 class="text-base font-bold font-jakarta text-primary-color">
+              Exercise
+            </h2>
+            <div class="flex flex-wrap gap-2">
+              <For each={exercisesWithData()}>
+                {(id) => {
+                  const ex = getExerciseById(id);
+                  return (
+                    <button
+                      class="text-xs font-inter font-medium px-3 py-1.5 rounded-lg"
+                      classList={{
+                        "bg-purple text-white-color": selected() === id,
+                        "bg-elevated text-secondary-color": selected() !== id,
+                      }}
+                      onClick={() => setSelectedExercise(id)}
+                    >
+                      {ex?.name ?? id}
+                    </button>
+                  );
+                }}
+              </For>
+            </div>
+          </div>
+
+          <Show when={isWeight()}>
+            <div class="flex flex-col gap-4">
+              <LineChart
+                data={maxWeightData()}
+                label="Max Weight"
+                unit="lb"
+                color="var(--accent-purple)"
+              />
+              <LineChart
+                data={volumeData()}
+                label="Total Volume"
+                unit="lb"
+                color="var(--accent-teal)"
+              />
+            </div>
+          </Show>
+
+          <Show when={!isWeight() && exercise()}>
+            <LineChart
+              data={cardioData()}
+              label={cardioLabel()}
+              unit={cardioUnit()}
+              color="var(--accent-teal)"
+            />
+          </Show>
+        </div>
+      </Show>
+    </Layout>
+  );
+};
+
+export default Progress;

--- a/packages/web/src/components/training/ExercisePicker.tsx
+++ b/packages/web/src/components/training/ExercisePicker.tsx
@@ -1,0 +1,107 @@
+import { type Component, For, createSignal, Show } from "solid-js";
+import { exercises, type Exercise, type ExerciseType } from "@barbell/shared";
+
+interface ExercisePickerProps {
+  onSelect: (exerciseId: string) => void;
+  onCancel: () => void;
+}
+
+const ExercisePicker: Component<ExercisePickerProps> = (props) => {
+  const [filter, setFilter] = createSignal<ExerciseType | "all">("all");
+  const [search, setSearch] = createSignal("");
+
+  const filtered = () =>
+    exercises.filter((e) => {
+      const matchesType = filter() === "all" || e.type === filter();
+      const matchesSearch =
+        search() === "" ||
+        e.name.toLowerCase().includes(search().toLowerCase());
+      return matchesType && matchesSearch;
+    });
+
+  return (
+    <div class="flex flex-col gap-4 rounded-xl p-4 bg-card">
+      <div class="flex items-center justify-between">
+        <h3 class="text-base font-bold font-jakarta text-primary-color">
+          Add Exercise
+        </h3>
+        <button
+          class="text-sm font-inter font-medium text-tertiary-color"
+          onClick={props.onCancel}
+        >
+          Cancel
+        </button>
+      </div>
+
+      <input
+        type="text"
+        placeholder="Search exercises..."
+        class="rounded-lg px-3 py-2 text-sm font-inter bg-elevated text-primary-color outline-none"
+        value={search()}
+        onInput={(e) => setSearch(e.currentTarget.value)}
+      />
+
+      <div class="flex gap-2">
+        <button
+          class="text-xs font-inter font-medium px-3 py-1.5 rounded-lg"
+          classList={{
+            "bg-purple text-white-color": filter() === "all",
+            "bg-elevated text-secondary-color": filter() !== "all",
+          }}
+          onClick={() => setFilter("all")}
+        >
+          All
+        </button>
+        <button
+          class="text-xs font-inter font-medium px-3 py-1.5 rounded-lg"
+          classList={{
+            "bg-purple text-white-color": filter() === "weight",
+            "bg-elevated text-secondary-color": filter() !== "weight",
+          }}
+          onClick={() => setFilter("weight")}
+        >
+          Weight
+        </button>
+        <button
+          class="text-xs font-inter font-medium px-3 py-1.5 rounded-lg"
+          classList={{
+            "bg-purple text-white-color": filter() === "cardio",
+            "bg-elevated text-secondary-color": filter() !== "cardio",
+          }}
+          onClick={() => setFilter("cardio")}
+        >
+          Cardio
+        </button>
+      </div>
+
+      <div class="flex flex-col gap-1 max-h-[240px] overflow-y-auto">
+        <Show
+          when={filtered().length > 0}
+          fallback={
+            <span class="text-sm font-inter text-tertiary-color py-2">
+              No exercises found
+            </span>
+          }
+        >
+          <For each={filtered()}>
+            {(exercise) => (
+              <button
+                class="flex items-center justify-between px-3 py-2.5 rounded-lg text-left hover:bg-elevated"
+                onClick={() => props.onSelect(exercise.id)}
+              >
+                <span class="text-sm font-inter font-medium text-primary-color">
+                  {exercise.name}
+                </span>
+                <span class="text-xs font-inter text-tertiary-color">
+                  {exercise.type === "weight" ? "Weight" : exercise.unit}
+                </span>
+              </button>
+            )}
+          </For>
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+export default ExercisePicker;

--- a/packages/web/src/components/training/SessionEditor.tsx
+++ b/packages/web/src/components/training/SessionEditor.tsx
@@ -266,6 +266,7 @@ const SessionEditor: Component<SessionEditorProps> = (props) => {
                     <input
                       type="number"
                       inputMode="numeric"
+                      min="1"
                       class="rounded-lg px-3 py-2 text-sm font-inter bg-elevated text-primary-color outline-none w-full"
                       placeholder="0"
                       value={weightInputs()[entryIndex()]?.reps ?? ""}
@@ -287,6 +288,7 @@ const SessionEditor: Component<SessionEditorProps> = (props) => {
                     <input
                       type="number"
                       inputMode="decimal"
+                      min="1"
                       class="rounded-lg px-3 py-2 text-sm font-inter bg-elevated text-primary-color outline-none w-full"
                       placeholder="0"
                       value={weightInputs()[entryIndex()]?.weight ?? ""}

--- a/packages/web/src/components/training/SessionEditor.tsx
+++ b/packages/web/src/components/training/SessionEditor.tsx
@@ -1,0 +1,363 @@
+import { type Component, For, Show, createSignal } from "solid-js";
+import {
+  type TrainingSession,
+  type WeightSet,
+  type CardioSet,
+  getExerciseById,
+} from "@barbell/shared";
+import ExercisePicker from "./ExercisePicker";
+
+interface SessionEditorProps {
+  session: TrainingSession;
+  onBack: () => void;
+  onAddExercise: (exerciseId: string) => void;
+  onRemoveExercise: (entryIndex: number) => void;
+  onAddWeightSet: (entryIndex: number, set: WeightSet) => void;
+  onAddCardioSet: (entryIndex: number, set: CardioSet) => void;
+  onRemoveSet: (entryIndex: number, setIndex: number) => void;
+}
+
+const SessionEditor: Component<SessionEditorProps> = (props) => {
+  const [showPicker, setShowPicker] = createSignal(false);
+  const [weightInputs, setWeightInputs] = createSignal<
+    Record<number, { reps: string; weight: string }>
+  >({});
+  const [cardioInputs, setCardioInputs] = createSignal<
+    Record<number, { value: string; duration: string }>
+  >({});
+
+  const handleAddExercise = (exerciseId: string) => {
+    props.onAddExercise(exerciseId);
+    setShowPicker(false);
+  };
+
+  const handleAddWeightSet = (entryIndex: number) => {
+    const input = weightInputs()[entryIndex];
+    const reps = parseInt(input?.reps || "0", 10);
+    const weight = parseFloat(input?.weight || "0");
+    if (reps > 0 && weight > 0) {
+      props.onAddWeightSet(entryIndex, { reps, weight });
+      setWeightInputs((prev) => ({
+        ...prev,
+        [entryIndex]: { reps: "", weight: "" },
+      }));
+    }
+  };
+
+  const handleAddCardioSet = (entryIndex: number) => {
+    const input = cardioInputs()[entryIndex];
+    const value = parseFloat(input?.value || "0");
+    const duration = input?.duration ? parseFloat(input.duration) : undefined;
+    if (value > 0) {
+      props.onAddCardioSet(entryIndex, {
+        value,
+        ...(duration ? { duration } : {}),
+      });
+      setCardioInputs((prev) => ({
+        ...prev,
+        [entryIndex]: { value: "", duration: "" },
+      }));
+    }
+  };
+
+  const formatDate = (dateStr: string) => {
+    const [year, month, day] = dateStr.split("-");
+    return `${month}/${day}/${year}`;
+  };
+
+  return (
+    <div class="flex flex-col gap-5">
+      <div class="flex items-center gap-3">
+        <button
+          class="flex items-center justify-center w-9 h-9 rounded-[18px] bg-elevated"
+          onClick={props.onBack}
+          aria-label="Back to sessions"
+        >
+          <svg
+            class="w-5 h-5 text-primary-color"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+        </button>
+        <span class="text-sm font-inter font-medium text-secondary-color">
+          {formatDate(props.session.date)}
+        </span>
+      </div>
+
+      <For each={props.session.entries}>
+        {(entry, entryIndex) => {
+          const exercise = () => getExerciseById(entry.exerciseId);
+          const isWeight = () => exercise()?.type === "weight";
+
+          return (
+            <div class="flex flex-col gap-3 rounded-xl p-4 bg-card">
+              <div class="flex items-center justify-between">
+                <h3 class="text-base font-bold font-jakarta text-primary-color">
+                  {exercise()?.name ?? entry.exerciseId}
+                </h3>
+                <button
+                  class="text-xs font-inter font-medium text-error"
+                  onClick={() => props.onRemoveExercise(entryIndex())}
+                >
+                  Remove
+                </button>
+              </div>
+
+              <Show when={entry.sets.length > 0}>
+                <div class="flex flex-col gap-1">
+                  <div class="flex gap-2 text-xs font-inter font-medium text-tertiary-color px-1">
+                    <span class="w-8">Set</span>
+                    <Show
+                      when={isWeight()}
+                      fallback={
+                        <>
+                          <span class="flex-1">
+                            {exercise()?.unit === "laps" ? "Laps" : "Time"}
+                          </span>
+                          <Show when={exercise()?.unit !== "laps"}>
+                            <span class="flex-1">Duration (s)</span>
+                          </Show>
+                        </>
+                      }
+                    >
+                      <span class="flex-1">Reps</span>
+                      <span class="flex-1">Weight (lb)</span>
+                    </Show>
+                    <span class="w-8" />
+                  </div>
+                  <For each={entry.sets}>
+                    {(set, setIdx) => (
+                      <div class="flex items-center gap-2 px-1 py-1">
+                        <span class="w-8 text-sm font-inter font-medium text-secondary-color">
+                          {setIdx() + 1}
+                        </span>
+                        <Show
+                          when={isWeight()}
+                          fallback={
+                            <>
+                              <span class="flex-1 text-sm font-inter font-semibold text-primary-color">
+                                {(set as CardioSet).value}
+                              </span>
+                              <Show when={exercise()?.unit !== "laps"}>
+                                <span class="flex-1 text-sm font-inter text-primary-color">
+                                  {(set as CardioSet).duration ?? "-"}
+                                </span>
+                              </Show>
+                            </>
+                          }
+                        >
+                          <span class="flex-1 text-sm font-inter font-semibold text-primary-color">
+                            {(set as WeightSet).reps}
+                          </span>
+                          <span class="flex-1 text-sm font-inter text-primary-color">
+                            {(set as WeightSet).weight} lb
+                          </span>
+                        </Show>
+                        <button
+                          class="w-8 flex items-center justify-center"
+                          onClick={() =>
+                            props.onRemoveSet(entryIndex(), setIdx())
+                          }
+                          aria-label={`Remove set ${setIdx() + 1}`}
+                        >
+                          <svg
+                            class="w-4 h-4 text-tertiary-color"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            stroke-width="2"
+                          >
+                            <path
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              d="M6 18L18 6M6 6l12 12"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    )}
+                  </For>
+                </div>
+              </Show>
+
+              <Show
+                when={isWeight()}
+                fallback={
+                  <div class="flex gap-2 items-end">
+                    <div class="flex flex-col gap-1 flex-1">
+                      <label class="text-xs font-inter text-tertiary-color">
+                        {exercise()?.unit === "laps" ? "Laps" : "Time"}
+                      </label>
+                      <input
+                        type="number"
+                        inputMode="decimal"
+                        class="rounded-lg px-3 py-2 text-sm font-inter bg-elevated text-primary-color outline-none w-full"
+                        placeholder="0"
+                        value={cardioInputs()[entryIndex()]?.value ?? ""}
+                        onInput={(e) =>
+                          setCardioInputs((prev) => ({
+                            ...prev,
+                            [entryIndex()]: {
+                              ...prev[entryIndex()],
+                              value: e.currentTarget.value,
+                            },
+                          }))
+                        }
+                      />
+                    </div>
+                    <Show when={exercise()?.unit !== "laps"}>
+                      <div class="flex flex-col gap-1 flex-1">
+                        <label class="text-xs font-inter text-tertiary-color">
+                          Duration (s)
+                        </label>
+                        <input
+                          type="number"
+                          inputMode="decimal"
+                          class="rounded-lg px-3 py-2 text-sm font-inter bg-elevated text-primary-color outline-none w-full"
+                          placeholder="0"
+                          value={cardioInputs()[entryIndex()]?.duration ?? ""}
+                          onInput={(e) =>
+                            setCardioInputs((prev) => ({
+                              ...prev,
+                              [entryIndex()]: {
+                                ...prev[entryIndex()],
+                                duration: e.currentTarget.value,
+                              },
+                            }))
+                          }
+                        />
+                      </div>
+                    </Show>
+                    <button
+                      class="flex items-center justify-center w-9 h-9 rounded-[18px] bg-purple shrink-0"
+                      onClick={() => handleAddCardioSet(entryIndex())}
+                      aria-label="Add set"
+                    >
+                      <svg
+                        class="w-4 h-4 text-white-color"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          d="M12 5v14m7-7H5"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                }
+              >
+                <div class="flex gap-2 items-end">
+                  <div class="flex flex-col gap-1 flex-1">
+                    <label class="text-xs font-inter text-tertiary-color">
+                      Reps
+                    </label>
+                    <input
+                      type="number"
+                      inputMode="numeric"
+                      class="rounded-lg px-3 py-2 text-sm font-inter bg-elevated text-primary-color outline-none w-full"
+                      placeholder="0"
+                      value={weightInputs()[entryIndex()]?.reps ?? ""}
+                      onInput={(e) =>
+                        setWeightInputs((prev) => ({
+                          ...prev,
+                          [entryIndex()]: {
+                            ...prev[entryIndex()],
+                            reps: e.currentTarget.value,
+                          },
+                        }))
+                      }
+                    />
+                  </div>
+                  <div class="flex flex-col gap-1 flex-1">
+                    <label class="text-xs font-inter text-tertiary-color">
+                      Weight (lb)
+                    </label>
+                    <input
+                      type="number"
+                      inputMode="decimal"
+                      class="rounded-lg px-3 py-2 text-sm font-inter bg-elevated text-primary-color outline-none w-full"
+                      placeholder="0"
+                      value={weightInputs()[entryIndex()]?.weight ?? ""}
+                      onInput={(e) =>
+                        setWeightInputs((prev) => ({
+                          ...prev,
+                          [entryIndex()]: {
+                            ...prev[entryIndex()],
+                            weight: e.currentTarget.value,
+                          },
+                        }))
+                      }
+                    />
+                  </div>
+                  <button
+                    class="flex items-center justify-center w-9 h-9 rounded-[18px] bg-purple shrink-0"
+                    onClick={() => handleAddWeightSet(entryIndex())}
+                    aria-label="Add set"
+                  >
+                    <svg
+                      class="w-4 h-4 text-white-color"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M12 5v14m7-7H5"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </Show>
+            </div>
+          );
+        }}
+      </For>
+
+      <Show
+        when={showPicker()}
+        fallback={
+          <button
+            class="flex items-center justify-center gap-2 rounded-xl h-[48px] bg-elevated text-primary-color font-medium font-inter text-sm w-full"
+            onClick={() => setShowPicker(true)}
+          >
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M12 5v14m7-7H5"
+              />
+            </svg>
+            Add Exercise
+          </button>
+        }
+      >
+        <ExercisePicker
+          onSelect={handleAddExercise}
+          onCancel={() => setShowPicker(false)}
+        />
+      </Show>
+    </div>
+  );
+};
+
+export default SessionEditor;

--- a/packages/web/src/components/training/SessionList.tsx
+++ b/packages/web/src/components/training/SessionList.tsx
@@ -1,0 +1,89 @@
+import { type Component, For, Show } from "solid-js";
+import { type TrainingSession, getExerciseById } from "@barbell/shared";
+
+interface SessionListProps {
+  sessions: TrainingSession[];
+  onStart: () => void;
+  onResume: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+const formatDate = (dateStr: string) => {
+  const [year, month, day] = dateStr.split("-");
+  return `${month}/${day}/${year}`;
+};
+
+const SessionList: Component<SessionListProps> = (props) => {
+  const sorted = () =>
+    [...props.sessions].sort((a, b) => b.date.localeCompare(a.date));
+
+  return (
+    <div class="flex flex-col gap-5">
+      <button
+        class="flex items-center justify-center gap-2 rounded-xl h-[56px] bg-purple text-white-color font-semibold font-inter text-base w-full"
+        onClick={props.onStart}
+      >
+        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m7-7H5" />
+        </svg>
+        New Session
+      </button>
+
+      <Show when={sorted().length > 0}>
+        <h2 class="text-xl font-bold font-jakarta text-primary-color">
+          Past Sessions
+        </h2>
+        <div class="flex flex-col gap-3">
+          <For each={sorted()}>
+            {(session) => (
+              <div class="flex flex-col gap-2 rounded-xl p-4 bg-card">
+                <div class="flex items-center justify-between">
+                  <span class="text-sm font-semibold font-inter text-secondary-color">
+                    {formatDate(session.date)}
+                  </span>
+                  <div class="flex gap-2">
+                    <button
+                      class="text-xs font-inter font-medium px-3 py-1 rounded-lg bg-elevated text-primary-color"
+                      onClick={() => props.onResume(session.id)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      class="text-xs font-inter font-medium px-3 py-1 rounded-lg text-error"
+                      onClick={() => props.onDelete(session.id)}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+                <Show
+                  when={session.entries.length > 0}
+                  fallback={
+                    <span class="text-sm font-inter text-tertiary-color">
+                      No exercises logged
+                    </span>
+                  }
+                >
+                  <div class="flex flex-wrap gap-1.5">
+                    <For each={session.entries}>
+                      {(entry) => {
+                        const exercise = getExerciseById(entry.exerciseId);
+                        return (
+                          <span class="text-xs font-inter font-medium px-2 py-1 rounded-md bg-elevated text-secondary-color">
+                            {exercise?.name ?? entry.exerciseId} ({entry.sets.length})
+                          </span>
+                        );
+                      }}
+                    </For>
+                  </div>
+                </Show>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default SessionList;

--- a/packages/web/src/components/training/Training.tsx
+++ b/packages/web/src/components/training/Training.tsx
@@ -1,0 +1,51 @@
+import { type Component, Show } from "solid-js";
+import Layout from "../Layout";
+import SessionList from "./SessionList";
+import SessionEditor from "./SessionEditor";
+import {
+  useTrainingStore,
+  useTrainingActions,
+  useActiveSession,
+} from "../../stores/trainingStore";
+
+const Training: Component = () => {
+  const store = useTrainingStore();
+  const actions = useTrainingActions();
+  const activeSession = useActiveSession();
+
+  return (
+    <Layout>
+      <header class="flex items-center justify-between py-4">
+        <h1 class="text-4xl font-bold font-jakarta text-primary-color">
+          Training
+        </h1>
+      </header>
+
+      <Show
+        when={activeSession()}
+        fallback={
+          <SessionList
+            sessions={store.sessions}
+            onStart={actions.startSession}
+            onResume={actions.resumeSession}
+            onDelete={actions.deleteSession}
+          />
+        }
+      >
+        {(session) => (
+          <SessionEditor
+            session={session()}
+            onBack={actions.clearActiveSession}
+            onAddExercise={actions.addExerciseEntry}
+            onRemoveExercise={actions.removeExerciseEntry}
+            onAddWeightSet={actions.addWeightSet}
+            onAddCardioSet={actions.addCardioSet}
+            onRemoveSet={actions.removeSet}
+          />
+        )}
+      </Show>
+    </Layout>
+  );
+};
+
+export default Training;

--- a/packages/web/src/stores/trainingStore.ts
+++ b/packages/web/src/stores/trainingStore.ts
@@ -1,0 +1,124 @@
+import { createStore, produce } from "solid-js/store";
+import { createRoot, createEffect } from "solid-js";
+import {
+  type TrainingSession,
+  type ExerciseEntry,
+  type WeightSet,
+  type CardioSet,
+  generateSessionId,
+  TRAINING_SESSIONS_STORAGE_KEY,
+} from "@barbell/shared";
+import { useLocalStorage } from "../utils/useLocalStorage";
+
+type TrainingStoreState = {
+  sessions: TrainingSession[];
+  activeSessionId: string | null;
+};
+
+const createTrainingStore = () => {
+  const [state, setState] = createStore<TrainingStoreState>({
+    sessions: useLocalStorage<TrainingSession[]>(TRAINING_SESSIONS_STORAGE_KEY, []),
+    activeSessionId: null,
+  });
+
+  const getActiveSession = () =>
+    state.sessions.find((s) => s.id === state.activeSessionId);
+
+  const actions = {
+    startSession: () => {
+      const session: TrainingSession = {
+        id: generateSessionId(),
+        date: new Date().toISOString().split("T")[0],
+        entries: [],
+      };
+      setState(
+        produce((s) => {
+          s.sessions.push(session);
+          s.activeSessionId = session.id;
+        })
+      );
+    },
+
+    resumeSession: (id: string) => {
+      setState("activeSessionId", id);
+    },
+
+    clearActiveSession: () => {
+      setState("activeSessionId", null);
+    },
+
+    deleteSession: (id: string) => {
+      setState(
+        produce((s) => {
+          s.sessions = s.sessions.filter((sess) => sess.id !== id);
+          if (s.activeSessionId === id) s.activeSessionId = null;
+        })
+      );
+    },
+
+    addExerciseEntry: (exerciseId: string) => {
+      const idx = state.sessions.findIndex((s) => s.id === state.activeSessionId);
+      if (idx === -1) return;
+      const entry: ExerciseEntry = { exerciseId, sets: [] };
+      setState(
+        produce((s) => {
+          s.sessions[idx].entries.push(entry);
+        })
+      );
+    },
+
+    removeExerciseEntry: (entryIndex: number) => {
+      const idx = state.sessions.findIndex((s) => s.id === state.activeSessionId);
+      if (idx === -1) return;
+      setState(
+        produce((s) => {
+          s.sessions[idx].entries.splice(entryIndex, 1);
+        })
+      );
+    },
+
+    addWeightSet: (entryIndex: number, set: WeightSet) => {
+      const idx = state.sessions.findIndex((s) => s.id === state.activeSessionId);
+      if (idx === -1) return;
+      setState(
+        produce((s) => {
+          (s.sessions[idx].entries[entryIndex].sets as WeightSet[]).push(set);
+        })
+      );
+    },
+
+    addCardioSet: (entryIndex: number, set: CardioSet) => {
+      const idx = state.sessions.findIndex((s) => s.id === state.activeSessionId);
+      if (idx === -1) return;
+      setState(
+        produce((s) => {
+          (s.sessions[idx].entries[entryIndex].sets as CardioSet[]).push(set);
+        })
+      );
+    },
+
+    removeSet: (entryIndex: number, setIndex: number) => {
+      const idx = state.sessions.findIndex((s) => s.id === state.activeSessionId);
+      if (idx === -1) return;
+      setState(
+        produce((s) => {
+          s.sessions[idx].entries[entryIndex].sets.splice(setIndex, 1);
+        })
+      );
+    },
+  };
+
+  createEffect(() => {
+    localStorage.setItem(
+      TRAINING_SESSIONS_STORAGE_KEY,
+      JSON.stringify(state.sessions)
+    );
+  });
+
+  return { state, actions, getActiveSession };
+};
+
+export const TrainingStore = createRoot(createTrainingStore);
+export const useTrainingStore = () => TrainingStore.state;
+export const useTrainingActions = () => TrainingStore.actions;
+export const useActiveSession = () => TrainingStore.getActiveSession;


### PR DESCRIPTION
Add ability to log training sessions with exercises, sets, reps and weight.
Sessions auto-set the current date. Supports weight-based exercises
(bench press, squat, deadlift, etc.) and cardio/time-based exercises
(200m run, laps, jump rope, etc.).

- Shared: exercise types, hardcoded exercise list, session types, tests
- Web: training store with localStorage persistence, session list/editor
  UI, exercise picker with search/filter, new Training tab in navigation

https://claude.ai/code/session_015UeLxfcPeEtzAJSAtwwae7