### PR TITLE
Add date editing to training session editor

### DIFF
--- a/packages/web/src/components/training/SessionEditor.tsx
+++ b/packages/web/src/components/training/SessionEditor.tsx
@@ -10,6 +10,7 @@ import ExercisePicker from "./ExercisePicker";
 interface SessionEditorProps {
   session: TrainingSession;
   onBack: () => void;
+  onUpdateDate: (date: string) => void;
   onAddExercise: (exerciseId: string) => void;
   onRemoveExercise: (entryIndex: number) => void;
   onAddWeightSet: (entryIndex: number, set: WeightSet) => void;
@@ -60,11 +61,6 @@ const SessionEditor: Component<SessionEditorProps> = (props) => {
     }
   };
 
-  const formatDate = (dateStr: string) => {
-    const [year, month, day] = dateStr.split("-");
-    return `${month}/${day}/${year}`;
-  };
-
   return (
     <div class="flex flex-col gap-5">
       <div class="flex items-center gap-3">
@@ -87,9 +83,12 @@ const SessionEditor: Component<SessionEditorProps> = (props) => {
             />
           </svg>
         </button>
-        <span class="text-sm font-inter font-medium text-secondary-color">
-          {formatDate(props.session.date)}
-        </span>
+        <input
+          type="date"
+          class="text-sm font-inter font-medium text-secondary-color bg-transparent outline-none border-none cursor-pointer"
+          value={props.session.date}
+          onChange={(e) => props.onUpdateDate(e.currentTarget.value)}
+        />
       </div>
 
       <For each={props.session.entries}>

--- a/packages/web/src/components/training/Training.tsx
+++ b/packages/web/src/components/training/Training.tsx
@@ -36,6 +36,7 @@ const Training: Component = () => {
           <SessionEditor
             session={session()}
             onBack={actions.clearActiveSession}
+            onUpdateDate={(date) => actions.updateSessionDate(session().id, date)}
             onAddExercise={actions.addExerciseEntry}
             onRemoveExercise={actions.removeExerciseEntry}
             onAddWeightSet={actions.addWeightSet}

--- a/packages/web/src/stores/trainingStore.ts
+++ b/packages/web/src/stores/trainingStore.ts
@@ -106,6 +106,15 @@ const createTrainingStore = () => {
         })
       );
     },
+
+    updateSessionDate: (id: string, date: string) => {
+      setState(
+        produce((s) => {
+          const session = s.sessions.find((sess) => sess.id === id);
+          if (session) session.date = date;
+        })
+      );
+    },
   };
 
   createEffect(() => {


### PR DESCRIPTION
- Add updateSessionDate action to trainingStore
- Replace static date display in SessionEditor with editable date input
- New sessions default to today's date (already the case via toISOString)
- Wire onUpdateDate prop through Training.tsx

https://claude.ai/code/session_01RTpTdjmrGxpVWDtaZTTJLd